### PR TITLE
fix: add associate models - New x News

### DIFF
--- a/models/comment.js
+++ b/models/comment.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      Comment.belongsTo(models.New, {
+      Comment.belongsTo(models.News, {
         as: 'new',
         foreignKey: 'id',
         target_key: 'post_id'


### PR DESCRIPTION
Cambio en el modelo de comment. al modelo News, en la asociación, no le agregue la 's'
```
  Comment.belongsTo(models.New, {
        as: 'new',
        foreignKey: 'id',
        target_key: 'post_id'
      });
```