### PR TITLE
OT200-88-agregar-paginacion-testimonios 

### DIFF
--- a/controllers/testimonials.controller.js
+++ b/controllers/testimonials.controller.js
@@ -1,6 +1,47 @@
-const create = require("../services/testimonial");
+const {create, find} = require("../services/testimonial");
 
-const getAllTestimonials = (req, res) => {};
+const getAllTestimonials = async (req, res) => {
+
+    try {
+
+        const { page } = req.query;
+
+        const currentPage = page && Number(page) > 0 ? Number(page) : 0;
+
+        const limit = 10;
+
+        const offset = currentPage * limit;
+
+        const prevPage = currentPage - 1;
+
+        const nextPage = currentPage + 1;
+
+        const testimonials = await find(offset, limit);
+
+        const { count } = testimonials;
+
+        const totalPages = Math.ceil(count / limit);
+
+        if(Number(currentPage) > totalPages - 1) return res.status(400).json( { messaje: `There are just ${totalPages} pages.` } );
+        
+        return res.json({ 
+            prevPage: `${ prevPage < 0 ? 'There is no previous page' : 'http://localhost:3000/testimonials?page=' + prevPage }`,            
+            currentPage: `http://localhost:3000/testimonials?page=${currentPage}`,
+            nextPage: `${ nextPage >= totalPages  ? 'There is no next page' : 'http://localhost:3000/testimonials?page=' + nextPage }`,
+            totalPages,
+            testimonials,
+        });         
+            
+    } catch (error) {
+
+        return res.status(500).json({
+            error: true,
+            message: "Something went wrong",
+        });
+        
+    }
+
+};
 
 const getOneTestiominal = (req, res) => {};
 

--- a/routes/testimonials.js
+++ b/routes/testimonials.js
@@ -1,17 +1,23 @@
 const express = require("express");
 const router = express.Router();
 
-const { createTestimonial } = require("../controllers/testimonials.controller");
+const { createTestimonial, getAllTestimonials } = require("../controllers/testimonials.controller");
 const validatorHandler = require("../middleware/validatorHandler");
 const { checkSchema } = require("express-validator");
 const testimonialSchema = require("../schemas/testimonial");
 const verifyToken = require("./../middleware/verifyToken")
 const checkAdmin = require("../middleware/checkAdmin");
 
+router.get(
+    "/",
+    verifyToken,
+    getAllTestimonials
+);
+
 router.post(
     "/",
-    // verifyToken,
-    // checkAdmin,
+    verifyToken,
+    checkAdmin,
     validatorHandler(checkSchema(testimonialSchema)),
     createTestimonial
 );

--- a/services/testimonial.js
+++ b/services/testimonial.js
@@ -8,4 +8,12 @@ const create = async (data) =>{
 
 }
 
-module.exports = create
+const find = async (offset, limit) => {
+    
+    const testimonials = await db.Testimonial.findAndCountAll({ offset, limit })
+
+    return testimonials;
+
+}
+
+module.exports = {create, find}


### PR DESCRIPTION
### Agregar paginación a Testimonios

COMO usuario
QUIERO visualizar los resultados de Testimonios paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page