### PR TITLE
OT200-67-modificar-enpoint-publico-de-organizations-para-devolver-links-redes-sociale

### DIFF
--- a/controllers/organizations.controller.js
+++ b/controllers/organizations.controller.js
@@ -1,0 +1,23 @@
+const getAll = require("../services/organizations");
+
+const getOrganizations = async (req, res) => {
+
+    try {
+
+        const organizations = await getAll();
+
+        return res.json(organizations);      
+
+    } catch (error) {
+      
+        return res.status(500).json({            
+            error: true,
+            message: "Something went wrong"
+        })
+
+    }
+
+}
+
+
+module.exports = getOrganizations;

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,6 +8,7 @@ const slidesRouter = require('./slides');
 const testimonialsRouter = require('./testimonials');
 const newsRouter = require('./news');
 const activitiesRouter = require('./activities')
+const organizationsRouter = require('./organizations')
 
 
 /* GET home page. */
@@ -25,6 +26,7 @@ router.use('/comments', commentsRouter);
 router.use('/slides', slidesRouter);
 router.use('/testimonials', testimonialsRouter);
 router.use('/activities',activitiesRouter)
+router.use('/organizations',organizationsRouter)
 
 
 module.exports = router;

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const getOrganizations = require("../controllers/organizations.controller");
+const router = express.Router();
+const verifyToken = require("./../middleware/verifyToken");
+
+
+router.get(
+  "/",
+  verifyToken,
+  getOrganizations
+);
+
+
+module.exports = router;

--- a/services/organizations.js
+++ b/services/organizations.js
@@ -2,7 +2,9 @@ const db = require("./../models/");
 
 const getAll = async () => {
 
-    const organizations = await db.Organization.findAll();
+    const organizations = await db.Organization.findAll({
+        attributes: ["facebookUrl", "instagramUrl", "linkedinUrl"],
+    });
 
     return organizations;
 }

--- a/services/organizations.js
+++ b/services/organizations.js
@@ -1,0 +1,10 @@
+const db = require("./../models/");
+
+const getAll = async () => {
+
+    const organizations = await db.Organization.findAll();
+
+    return organizations;
+}
+
+module.exports = getAll;


### PR DESCRIPTION
### Modificar endpoint público de organizations para devolver links de redes sociales

COMO usuario
QUIERO ver los links de las redes sociales al entrar a la página
PARA poder acceder a ellas.

Criterios de aceptación:
- Al devolver los datos en el endpoint de datos públicos, agregar los campos de redes sociales en la respuesta